### PR TITLE
CDEC snow course login and measurementDate logic

### DIFF
--- a/metloom/pointdata/base.py
+++ b/metloom/pointdata/base.py
@@ -64,7 +64,7 @@ class PointData(object):
     ALLOWED_VARIABLES = VariableBase
     ITERATOR_CLASS = PointDataCollection
     DATASOURCE = None
-    EXPECTED_COLUMNS = ["measurementDate", "geometry", "datasource"]
+    EXPECTED_COLUMNS = ["geometry", "datasource"]
     EXPECTED_INDICES = ["datetime", "site"]
     NON_VARIABLE_COLUMNS = EXPECTED_INDICES + EXPECTED_COLUMNS
 
@@ -232,9 +232,12 @@ class PointData(object):
         for ei in cls.EXPECTED_INDICES:
             assert ei in index_names
         # check for expected columns
+        expected_columns = cls.EXPECTED_COLUMNS
+        if "measurementDate" in columns:
+            expected_columns = expected_columns + ["measurementDate"]
         for column in cls.EXPECTED_COLUMNS:
             assert column in columns
-        remaining_columns = [c for c in columns if c not in cls.EXPECTED_COLUMNS]
+        remaining_columns = [c for c in columns if c not in expected_columns]
         # make sure all variables have a units column as well
         for rc in remaining_columns:
             if "_units" not in rc:

--- a/metloom/pointdata/cdec.py
+++ b/metloom/pointdata/cdec.py
@@ -190,6 +190,9 @@ class CDECPointData(PointData):
             variables: List of metloom.variables.SensorDescription object
                 from self.ALLOWED_VARIABLES
             duration: CDEC duration code ['M', 'H', 'D']
+            include_measurement_date: boolean for including the
+                'measurmentDate' column in the resulting dataframe. This column
+                is only relevant for snow courses
         Returns:
             GeoDataFrame of data, indexed on datetime, site
         """

--- a/metloom/pointdata/cdec.py
+++ b/metloom/pointdata/cdec.py
@@ -47,7 +47,7 @@ class CDECPointData(PointData):
             self._raw_metadata = resp.json()["STATION"]
         return self._raw_metadata
 
-    def is_only_snow_course(self):
+    def is_only_snow_course(self, variables: List[SensorDescription]):
         """
         Determine if a station only has snow course measurements
         """
@@ -59,10 +59,19 @@ class CDECPointData(PointData):
         if result and not self.is_only_monthly():
             # This would happen if all snow sensors have code "M"
             # but there are other hourly or daily sensors
-            raise Exception(
-                f"We have not accounted for this scenario. Please talk to "
-                f"a Micah about how {self.id} violates their assumptions."
-            )
+            if any(
+                [sensor not in [
+                    self.ALLOWED_VARIABLES.SWE, self.ALLOWED_VARIABLES.SNOWDEPTH
+                ] for sensor in variables]
+            ):
+                # this is an acceptable scenario where we are looking for
+                # more than just snow variables and the station has them
+                result = False
+            else:
+                # We are only looking for snow variables and this only has
+                # monthly snow variables so it is effectively only
+                # a snow course
+                result = True
         return result
 
     def is_partly_snow_course(self):
@@ -139,14 +148,17 @@ class CDECPointData(PointData):
         )
         sensor_df.replace(-9999.0, np.nan, inplace=True)
         # this mapping is important. Sometimes obsDate is null
+        column_map = {
+            "date": "datetime",
+            "value": sensor.name,
+            "units": f"{sensor.name}_units",
+            "stationId": "site",
+        }
+        if "measurementDate" in final_columns:
+            column_map["obsDate"] = "measurementDate"
+
         sensor_df.rename(
-            columns={
-                "date": "datetime",
-                "obsDate": "measurementDate",
-                "value": sensor.name,
-                "units": f"{sensor.name}_units",
-                "stationId": "site",
-            },
+            columns=column_map,
             inplace=True,
         )
         final_columns += [sensor.name, f"{sensor.name}_units"]
@@ -157,9 +169,6 @@ class CDECPointData(PointData):
             sensor_df["measurementDate"] = sensor_df["measurementDate"].apply(
                 self._handle_df_tz
             )
-        else:
-            LOG.warning(f"measurementDate not found for {self.name} for"
-                        f"sensor {sensor.code}")
         # set index so joinng works
         sensor_df.set_index("datetime", inplace=True)
         sensor_df = sensor_df.filter(final_columns)
@@ -172,6 +181,7 @@ class CDECPointData(PointData):
         end_date: datetime,
         variables: List[SensorDescription],
         duration: str,
+        include_measurement_date=False
     ):
         """
         Args:
@@ -190,7 +200,9 @@ class CDECPointData(PointData):
             "End": end_date.isoformat(),
         }
         df = None
-        final_columns = ["geometry", "site", "measurementDate"]
+        final_columns = ["geometry", "site"]
+        if include_measurement_date:
+            final_columns += ["measurementDate"]
         for sensor in variables:
             params["SensorNums"] = sensor.code
             response_data = self._data_request(params)
@@ -248,7 +260,9 @@ class CDECPointData(PointData):
         """
         if not self.is_partly_snow_course():
             raise ValueError(f"{self.id} is not a snow course")
-        return self._get_data(start_date, end_date, variables, "M")
+        return self._get_data(
+            start_date, end_date, variables, "M", include_measurement_date=True
+        )
 
     @staticmethod
     def _station_sensor_search(
@@ -354,5 +368,5 @@ class CDECPointData(PointData):
             return cls.ITERATOR_CLASS([p for p in points if p.is_partly_snow_course()])
         else:
             return cls.ITERATOR_CLASS(
-                [p for p in points if not p.is_only_snow_course()]
+                [p for p in points if not p.is_only_snow_course(variables)]
             )

--- a/metloom/pointdata/snotel.py
+++ b/metloom/pointdata/snotel.py
@@ -48,7 +48,13 @@ class SnotelPointData(PointData):
         """
         Convert the response from climata.snotel classes into
         Args:
-           result_map: map of the sensors to the list of API results
+        result_map: map of the sensors to the list of API results
+        duration: string representation of the duration tag for the
+            API (i.e. HOURLY)
+        include_measurement_date: boolean for including the
+            'measurementDate' column in the resulting dataframe. This column
+            is only relevant for snow courses
+
         """
         df = None
         # TODO: possible DRY opportunity here too

--- a/tests/test_cdec.py
+++ b/tests/test_cdec.py
@@ -101,9 +101,6 @@ class TestCDECStation(BasePointDataTest):
                 {
                     "datetime": pd.Timestamp("2021-05-15 08:00:00+0000",
                                              tz="UTC"),
-                    "measurementDate": pd.Timestamp(
-                        "2021-05-15 08:00:00+0000", tz="UTC"
-                    ),
                     "ACCUMULATED PRECIPITATION": np.nan,
                     "ACCUMULATED PRECIPITATION_units": np.nan,
                     "AVG AIR TEMP": 2.1,
@@ -113,9 +110,6 @@ class TestCDECStation(BasePointDataTest):
                 },
                 {
                     "datetime": pd.Timestamp("2021-05-16 08:00:00+0000", tz="UTC"),
-                    "measurementDate": pd.Timestamp(
-                        "2021-05-16 08:00:00+0000", tz="UTC"
-                    ),
                     "ACCUMULATED PRECIPITATION": -0.11,
                     "ACCUMULATED PRECIPITATION_units": "INCHES",
                     "AVG AIR TEMP": np.nan,
@@ -125,9 +119,6 @@ class TestCDECStation(BasePointDataTest):
                 },
                 {
                     "datetime": pd.Timestamp("2021-05-17 08:00:00+0000", tz="UTC"),
-                    "measurementDate": pd.Timestamp(
-                        "2021-05-17 08:00:00+0000", tz="UTC"
-                    ),
                     "ACCUMULATED PRECIPITATION": -0.10,
                     "ACCUMULATED PRECIPITATION_units": "INCHES",
                     "AVG AIR TEMP": 2.4,
@@ -137,9 +128,6 @@ class TestCDECStation(BasePointDataTest):
                 },
                 {
                     "datetime": pd.Timestamp("2021-05-18 08:00:00+0000", tz="UTC"),
-                    "measurementDate": pd.Timestamp(
-                        "2021-05-18 08:00:00+0000", tz="UTC"
-                    ),
                     "ACCUMULATED PRECIPITATION": -0.10,
                     "ACCUMULATED PRECIPITATION_units": "INCHES",
                     "AVG AIR TEMP": 2.2,

--- a/tests/test_point_data.py
+++ b/tests/test_point_data.py
@@ -29,7 +29,8 @@ class BasePointDataTest(object):
         return gpd.read_file(fp)
 
     @staticmethod
-    def expected_response(dates, variables_map, station, points, include_measurement_date=False):
+    def expected_response(dates, variables_map, station, points,
+                          include_measurement_date=False):
         obj = []
         for idt, dt in enumerate(dates):
             # get the value and unit corresponding to the date

--- a/tests/test_point_data.py
+++ b/tests/test_point_data.py
@@ -29,19 +29,21 @@ class BasePointDataTest(object):
         return gpd.read_file(fp)
 
     @staticmethod
-    def expected_response(dates, variables_map, station, points):
+    def expected_response(dates, variables_map, station, points, include_measurement_date=False):
         obj = []
         for idt, dt in enumerate(dates):
             # get the value and unit corresponding to the date
             row_obj = {k: v[idt] for k, v in variables_map.items()}
+            entry = {
+                "datetime": pd.Timestamp(dt, tz="UTC"),
+                "site": station.id,
+                "datasource": "NRCS",
+                **row_obj
+            }
+            if include_measurement_date:
+                entry["measurementDate"] = pd.Timestamp(dt, tz="UTC")
             obj.append(
-                {
-                    "datetime": pd.Timestamp(dt, tz="UTC"),
-                    "measurementDate": pd.Timestamp(dt, tz="UTC"),
-                    "site": station.id,
-                    "datasource": "NRCS",
-                    **row_obj
-                }
+                entry
             )
         df = gpd.GeoDataFrame.from_dict(
             obj,

--- a/tests/test_snotel.py
+++ b/tests/test_snotel.py
@@ -293,7 +293,8 @@ class TestSnotelPointData(BasePointDataTest):
         fn = getattr(station, fn_name)
         result = fn(d1, d2, vrs)
         expected = self.expected_response(
-            expected_dts, vals, station, points
+            expected_dts, vals, station, points,
+            include_measurement_date="snow_course" in fn_name
         )
         pd.testing.assert_frame_equal(result, expected)
 


### PR DESCRIPTION
- Check which sensors we're looking for when deciding if a station is only a snow course for cdec. This allows us to account for stations that have snow course measurements, but also have hourly/daily met sensors
- Do not include measurementDate except for snow courses. This is not a helpful data point for other outputs and causes issues in merging dataframes sometimes.