### PR TITLE
Utilze map keys for cli arg choices to make help easier to understand

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -41,7 +41,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
           matrix:
-            python-version: [3.7, 3.8, 3.9, '3.10', '3.11']
+            python-version: [3.8, 3.9, '3.10', '3.11']
 
         steps:
           - uses: actions/checkout@v2

--- a/metloom/cli.py
+++ b/metloom/cli.py
@@ -22,7 +22,7 @@ def main():
     )
     parser.add_argument(
         "--datasource", "-ds", dest="datasource",
-        choices=list(datasouce_map.values()), type=datasouce_map.get,
+        choices=list(datasouce_map.keys()),
         required=True, help="datasource used to find measurement ids"
     )
     parser.add_argument(
@@ -44,7 +44,7 @@ def main():
     )
 
     args = parser.parse_args()
-    datasource = args.datasource
+    datasource = datasouce_map.get(args.datasource)
     if datasource is None:
         raise ValueError("Not a valid datasource")
     geometry = gpd.read_file(args.shapefile)

--- a/metloom/pointdata/csas.py
+++ b/metloom/pointdata/csas.py
@@ -28,6 +28,7 @@ class CSASStationInfo(StationInfo):
 class CSASMet(CSVPointData):
     """
     """
+    CURRENT_AVAILABLE_YEAR = 2023
     ALLOWED_VARIABLES = CSASVariables
     ALLOWED_STATIONS = CSASStationInfo
 
@@ -48,7 +49,7 @@ class CSASMet(CSVPointData):
         urls = []
 
         if station_id in ['SASP', 'SBSP']:
-            current_available_year = datetime.today().year - 1
+            current_available_year = self.CURRENT_AVAILABLE_YEAR
 
             if start.year <= 2009:
                 urls.append(os.path.join(self.URL, self._station_info.path))

--- a/tests/test_cdec.py
+++ b/tests/test_cdec.py
@@ -627,7 +627,7 @@ class TestCdecUptime:
         return point
 
     def test_metadata(self, tum):
-        assert tum.metadata == shapely.geometry.Point(-119.348096, 37.876406, 8600)
+        assert tum.metadata == shapely.geometry.Point(-119.3499675, 37.876215, 8500)
 
     def test_is_snowcourse(self, tum):
         assert tum.is_partly_snow_course()

--- a/tests/test_csas.py
+++ b/tests/test_csas.py
@@ -115,7 +115,7 @@ class TestCSASMet:
          datetime(2003, 1, 1)),
         # Test post 2023 exception
         ('SBSP', datetime(2010, 1, 1),
-         datetime(2024, 1, 1))
+         datetime(2030, 1, 1))
     ])
     def test_file_urls_exception(self, station_id, start, end):
         """


### PR DESCRIPTION
Just a little change to make the --help easier to understand 
```
usage: metloom [-h] --shapefile SHAPEFILE --datasource {cdec,snotel} --variables VARIABLES [VARIABLES ...] [--snowcourse] [--ouput OUTPUT]

Find measurement locations within a shapefile

options:
  -h, --help            show this help message and exit
  --shapefile SHAPEFILE, -sf SHAPEFILE
                        shapefile used to filter measurement locations
  --datasource {cdec,snotel}, -ds {cdec,snotel}
```