### PR TITLE
Fix for 3_months_ago_bug in geosphere reader

### DIFF
--- a/metloom/pointdata/geosphere_austria.py
+++ b/metloom/pointdata/geosphere_austria.py
@@ -6,7 +6,7 @@ import numpy as np
 import pandas as pd
 import requests
 import logging
-
+from dateutil.relativedelta import relativedelta
 from geopandas import GeoDataFrame
 
 from .base import PointData
@@ -324,13 +324,7 @@ class GeoSphereCurrentPointData(GeoSpherePointDataBase):
 
     @staticmethod
     def _back_3_months(dt):
-        start_month = dt.month - 3
-        if start_month <= 0:
-            data_valid_start = dt.replace(
-                month=start_month + 12, year=dt.year - 1
-            )
-        else:
-            data_valid_start = dt.replace(month=start_month)
+        data_valid_start = dt - relativedelta(months=3)
         return data_valid_start
 
     def _validate_dates(self, end_date):

--- a/metloom/pointdata/geosphere_austria.py
+++ b/metloom/pointdata/geosphere_austria.py
@@ -6,7 +6,6 @@ import numpy as np
 import pandas as pd
 import requests
 import logging
-from dateutil.relativedelta import relativedelta
 from geopandas import GeoDataFrame
 
 from .base import PointData
@@ -324,7 +323,7 @@ class GeoSphereCurrentPointData(GeoSpherePointDataBase):
 
     @staticmethod
     def _back_3_months(dt):
-        data_valid_start = dt - relativedelta(months=3)
+        data_valid_start = dt - pd.DateOffset(months=3)
         return data_valid_start
 
     def _validate_dates(self, end_date):

--- a/tests/test_geosphere.py
+++ b/tests/test_geosphere.py
@@ -89,6 +89,9 @@ class TestGeoSphereCurrentPointData(BasePointDataTest):
             (datetime(2024, 1, 24), datetime(2023, 10, 24)),
             (datetime(2023, 6, 24), datetime(2023, 3, 24)),
             (datetime(2023, 3, 1), datetime(2022, 12, 1)),
+            # Check 3 months ago accounts for february dates
+            (datetime(2025, 5, 30), datetime(2025, 2, 28)),
+
         ]
     )
     def test_back_3_months(self, dt, expected, station):


### PR DESCRIPTION
The geosphere reader requires check for the requests are within 3 months. This 3 months calculation was causing invalid dates sometimes. Like on today 5-30-2025 would yield 02-30-2025 which is invalid. This function now relies on dateutils which offers handling of such things. 

Fixes #130 