### PR TITLE
Added missing cls arg to MesowestPointData.create_token_json

### DIFF
--- a/metloom/pointdata/mesowest.py
+++ b/metloom/pointdata/mesowest.py
@@ -356,7 +356,7 @@ class MesowestPointData(PointData):
         return cls.ITERATOR_CLASS(points)
 
     @classmethod
-    def create_token_json(token):
+    def create_token_json(cls, token):
         """
         Creates the neccessary synoptic token json for mesowest requests.
         To get public token visit: https://synopticdata.com/mesonet-api


### PR DESCRIPTION
This PR fixes the bug where calling
```python
MesowestPointData.create_token_json(token="mytoken123")
```
raised a ```TypeError```:
```bash
TypeError: MesowestPointData.create_token_json() takes 1 positional argument but 2 were given
```

## Fix

Added ```cls``` as the first argument to the method definition ```create_token_json```.

## Testing

Verified that calling ```MesowestPointData.create_token_json(token="mytoken123")``` now successfully creates a file containing the API token.

Confirmed no regression in tests.

## Linked Issue

Closes #138 