### PR TITLE
fix links and RH for CSAS

### DIFF
--- a/metloom/variables.py
+++ b/metloom/variables.py
@@ -464,8 +464,8 @@ class CSASVariables(VariableBase):
     """
 
     SNOWDEPTH = SensorDescription("Sno_Height_M", "SNOWDEPTH", units="meters")
-    RH = SensorDescription("Lo_RH", "RELATIVE HUMIDITY", units="%")
-    RH_UP = SensorDescription("Up_RH", "RELATIVE HUMIDITY", units="%")
+    RH_LOWER = SensorDescription("Lo_RH", "RELATIVE HUMIDITY", units="%")
+    RH_UPPER = SensorDescription("Up_RH", "RELATIVE HUMIDITY", units="%")
 
     STREAMFLOW_CFS = SensorDescription("Discharge_CFS", "STREAMFLOW", units="CFS")
     SURF_TEMP = SensorDescription(


### PR DESCRIPTION
Update RH nomenclature and links to variable descriptions. Note that from a very cursory look at the Lo_RH and Up_RH (two sensors on the same tower or so it seems) there is minimal difference except at some peaks where a diff is noticeable. 
<img width="628" height="470" alt="image" src="https://github.com/user-attachments/assets/8a1beae6-8dd8-4f4e-9e78-02dd363c7c41" />


